### PR TITLE
Added handling for scenarios where the source entities are unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ I put a lot of work into making this repo and component available and updated to
   Determines whether, if the source entity is unavailable and that is ignored (`ignore_undef`), it is assumed that the last valid status is valid until now(value 1). For example, if at 8 o'clock the entity had a value of 112 and was then unavailable, if this option is enabled, it is assumed that the entity retains this value until now (assuming it is now 9 o'clock) and this is calculated. If this option is disabled, the calculation only considers the period up to 8 o'clock and the time period from then until now is omitted.
   ignore_undef must be set to 1 in order to use this option.
   _Default value: 0_
+
 **duration**:\
   _(time) (Optional)_\
   Duration of the measure.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ I put a lot of work into making this repo and component available and updated to
   _(template) (Optional)_\
   When to stop the measure (timestamp or datetime).
 
+**ignore_undef**:\
+  _(template) (Optional)_\
+  Determines whether the average entity should become unavailable if all source entities become unavailable(value 0), or whether it should simply calculate the average up to the last known value and timestamp of the source entity, even if the latest values are unavailable(value 1).
+  _Default value: 0_
+
+**calculate_to_now_undef**:\
+  _(template) (Optional)_\
+  Determines whether, if the source entity is unavailable and that is ignored (`ignore_undef`), it is assumed that the last valid status is valid until now(value 1). For example, if at 8 o'clock the entity had a value of 112 and was then unavailable, if this option is enabled, it is assumed that the entity retains this value until now (assuming it is now 9 o'clock) and this is calculated. If this option is disabled, the calculation only considers the period up to 8 o'clock and the time period from then until now is omitted.
+  ignore_undef must be set to 1 in order to use this option.
+  _Default value: 0_
 **duration**:\
   _(time) (Optional)_\
   Duration of the measure.

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ I put a lot of work into making this repo and component available and updated to
 
 **ignore_undef**:\
   _(template) (Optional)_\
-  Determines whether the average entity should become unavailable if all source entities become unavailable(value 0), or whether it should simply calculate the average up to the last known value and timestamp of the source entity, even if the latest values are unavailable(value 1).
-  _Default value: 0_
+  Determines whether the average entity should become unavailable if all source entities become unavailable(value 0), or whether it should simply calculate the average up to the last known value and timestamp of the source entity, even if the latest values are unavailable(value 1).\
+ _Default value: 0_
 
 **calculate_to_now_undef**:\
   _(template) (Optional)_\
   Determines whether, if the source entity is unavailable and that is ignored (`ignore_undef`), it is assumed that the last valid status is valid until now(value 1). For example, if at 8 o'clock the entity had a value of 112 and was then unavailable, if this option is enabled, it is assumed that the entity retains this value until now (assuming it is now 9 o'clock) and this is calculated. If this option is disabled, the calculation only considers the period up to 8 o'clock and the time period from then until now is omitted.
-  ignore_undef must be set to 1 in order to use this option.
+  ignore_undef must be set to 1 in order to use this option\
   _Default value: 0_
 
 **duration**:\

--- a/custom_components/average/const.py
+++ b/custom_components/average/const.py
@@ -37,6 +37,9 @@ CONF_DURATION: Final = "duration"
 CONF_PRECISION: Final = "precision"
 CONF_PERIOD_KEYS: Final = [CONF_START, CONF_END, CONF_DURATION]
 CONF_PROCESS_UNDEF_AS: Final = "process_undef_as"
+CONF_IGNORE_UNDEF_VAL: Final = "ignore_undef"
+CONF_CALCULATE_TILL_NOW_UNDEF_VAL: Final = "calculate_to_now_undef"
+
 
 # Defaults
 DEFAULT_NAME: Final = "Average"

--- a/custom_components/average/sensor.py
+++ b/custom_components/average/sensor.py
@@ -78,6 +78,8 @@ from .const import (
     CONF_PRECISION,
     CONF_PROCESS_UNDEF_AS,
     CONF_START,
+    CONF_IGNORE_UNDEF_VAL,
+    CONF_CALCULATE_TILL_NOW_UNDEF_VAL,
     DEFAULT_NAME,
     DEFAULT_PRECISION,
     UPDATE_MIN_TIME,
@@ -109,6 +111,8 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(CONF_DURATION): cv.positive_time_period,
             vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): int,
             vol.Optional(CONF_PROCESS_UNDEF_AS): vol.Any(int, float),
+            vol.Optional(CONF_IGNORE_UNDEF_VAL, default=0): int,
+            vol.Optional(CONF_CALCULATE_TILL_NOW_UNDEF_VAL, default=0): int,
         }
     ),
     check_period_keys,
@@ -161,6 +165,8 @@ class AverageSensor(SensorEntity):
         self._period = self.start = self.end = None
         self._precision = config.get(CONF_PRECISION, DEFAULT_PRECISION)
         self._undef = config.get(CONF_PROCESS_UNDEF_AS)
+        self.ignoreundef = config.get(CONF_IGNORE_UNDEF_VAL)
+        self.calculatetillnowundef = config.get(CONF_CALCULATE_TILL_NOW_UNDEF_VAL)
         self._temperature_mode = None
         self._actual_end = None
 
@@ -209,7 +215,12 @@ class AverageSensor(SensorEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self.available_sources > 0 and self._has_state(self._attr_native_value)
+        if self.ignoreundef == 0:
+            return self.available_sources > 0 and self._has_state(
+                self._attr_native_value
+            )
+        else:
+            return True
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
@@ -377,6 +388,15 @@ class AverageSensor(SensorEntity):
                         'Parsing error: field "end" must be a datetime or a timestamp'
                     )
                     return
+            if (
+                (end is not None or start is not None)
+                and self.ignoreundef == 0
+                and self.calculatetillnowundef == 1
+            ):
+                _LOGGER.exception(
+                    "Wrong Configuration! You cant set calculate_to_end_undef to 1 when ignore_undef is 0 / not set"
+                )
+                return
 
         # Calculate start or end using the duration
         if self._duration is not None:
@@ -522,6 +542,7 @@ class AverageSensor(SensorEntity):
                 item = history_list[entity_id][0]
                 _LOGGER.debug("Initial historical state: %s", item)
                 last_state = None
+                isPlaceholderState = False
                 last_time = start_ts
                 if item is not None and self._has_state(item.state):
                     last_state = self._get_state_value(item)
@@ -532,18 +553,36 @@ class AverageSensor(SensorEntity):
                     current_state = self._get_state_value(item)
                     current_time = item.last_changed.timestamp()
 
-                    if last_state is not None:
+                    if last_state is not None and isPlaceholderState is False:
                         last_elapsed = current_time - last_time
                         value += last_state * last_elapsed
                         elapsed += last_elapsed
-
-                    last_state = current_state
-                    last_time = current_time
+                        # we need a valid last state if we want to calculate up to now(calculatetillnowundef) and the last state is undefined
+                        if self.calculatetillnowundef == 1:
+                            last_state = current_state
+                            last_time = current_time
+                            isPlaceholderState = True
+                        # we dont set last_state and last_time to undefined values when calculatetillnowundef is active and the last value is undefined
+                    if (
+                        current_state is None and self.calculatetillnowundef == 0
+                    ) or current_state is not None:
+                        last_state = current_state
+                        last_time = current_time
 
                 # Count time elapsed between last history state and now
-                if last_state is None:
+                # If the last value of the source sensor is undefined and the user does not ignore this (ignoreundef), the average sensor is also undefined
+                if last_state is None and self.ignoreundef == 0:
                     value = None
-                else:
+                # If the last value of the source sensor is undefined and the user ignores this but does not want to calculate to the end, the average sensor returns the average from the start to the last defined value
+                elif (
+                    last_state is None
+                    and self.ignoreundef == 1
+                    and self.calculatetillnowundef == 0
+                ):
+                    if elapsed:
+                        value /= elapsed
+                # If the last value is undefined and ignored, calculate the average to the end, assuming the last known value remains constant until now.
+                elif last_state is not None:
                     last_elapsed = end_ts - last_time
                     value += last_state * last_elapsed
                     elapsed += last_elapsed
@@ -555,7 +594,10 @@ class AverageSensor(SensorEntity):
 
             if isinstance(value, numbers.Number):
                 values.append(value)
-                self.available_sources += 1
+                if last_state is None:
+                    self.available_sources = 0
+                else:
+                    self.available_sources += 1
 
             if isinstance(trending_last_state, numbers.Number):
                 last_values.append(trending_last_state)

--- a/custom_components/average/sensor.py
+++ b/custom_components/average/sensor.py
@@ -388,15 +388,6 @@ class AverageSensor(SensorEntity):
                         'Parsing error: field "end" must be a datetime or a timestamp'
                     )
                     return
-            if (
-                (end is not None or start is not None)
-                and self.ignoreundef == 0
-                and self.calculatetillnowundef == 1
-            ):
-                _LOGGER.exception(
-                    "Wrong Configuration! You cant set calculate_to_end_undef to 1 when ignore_undef is 0 / not set"
-                )
-                return
 
         # Calculate start or end using the duration
         if self._duration is not None:
@@ -410,6 +401,15 @@ class AverageSensor(SensorEntity):
 
         _LOGGER.debug("Calculation period: start=%s, end=%s", start, end)
         if start is None or end is None:
+            return
+        if (
+            (end is not None or start is not None)
+            and self.ignoreundef == 0
+            and self.calculatetillnowundef == 1
+        ):
+            _LOGGER.exception(
+                "Wrong Configuration! You cant set calculate_to_end_undef to 1 when ignore_undef is 0 / not set"
+            )
             return
 
         if start > end:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional inmation section.formation section.
-->
The average entities are now no longer unavailable if the source sensor(s) are unavailable. This behavior is deactivated by default and must be activated by the user in the configuration.

Additionally, there is now an option for users to calculate the average value up to the last known value of the entity that was not unavailable. If the user ignores unavailable entities, that is the default option as the calculation happens as soon as the entities are unavailable. Alternatively, the user can choose to assume that the last value before unavailability is valid until now and calculate accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: average
    unique_id: 35806f32-628e-4b98-a9db-20e424ba2b22
    name: 'Effizienz Akku heute gesamt'
    start: "{{ now().replace(hour=0).replace(minute=0).replace(second=0) }}"
    end: "{{ now().replace(hour=23).replace(minute=59).replace(second=59) }}"
    ignore_undef: 1
    calculate_to_now_undef: 1
    entities:
      - sensor.noah_2000_effizenz
```


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`python3 -m ruff format custom_components`)
- [ ] The code quality has been checked using Ruff (`python3 -m ruff check custom_components --fix`)

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
